### PR TITLE
GH 19 - Add matrix endpoint

### DIFF
--- a/src/api/handlers.go
+++ b/src/api/handlers.go
@@ -92,6 +92,11 @@ func MakeArt(context *gin.Context) {
 		date = helpers.FindFirstSunday(date)
 		designs.DrawWord(json.Word, date)
 	}
+	if json.Pattern == "matrix" {
+		date = helpers.FindFirstSunday(date)
+		designs.DrawMatixPatern(date, json.Matrix.Matrix)
+	}
+
 	os.Chdir("..")
 
 	zipFile := fmt.Sprintf("%v.zip", json.RepoName)

--- a/src/api/handlers.go
+++ b/src/api/handlers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"git-art/src/designs"
 	"git-art/src/helpers"
+	"git-art/src/models"
 	"log"
 	"net/http"
 	"os"
@@ -15,12 +16,13 @@ import (
 
 // Request object that api accepts for generating git pattern
 type Request struct {
-	Name     string `json:"name" binding:"required"`
-	Email    string `json:"email" binding:"required"`
-	Pattern  string `json:"pattern" binding:"required"`
-	Word     string `json:"word"`
-	Year     int    `json:"year,string" binding:"required"`
-	RepoName string `json:"repoName" binding:"required"`
+	Name     string               `json:"name" binding:"required"`
+	Email    string               `json:"email" binding:"required"`
+	Pattern  string               `json:"pattern" binding:"required"`
+	Word     string               `json:"word"`
+	Year     int                  `json:"year,string" binding:"required"`
+	RepoName string               `json:"repoName" binding:"required"`
+	Matrix   models.MatrixRequest `json:"matrixObj"`
 }
 
 // Ping for ping/pong default endpoint

--- a/src/helpers/helpers_test.go
+++ b/src/helpers/helpers_test.go
@@ -43,4 +43,5 @@ func TestCommit(t *testing.T) {
 	if !os.IsNotExist(err) {
 		t.Errorf("No index file means commit was not created")
 	}
+	os.RemoveAll("./test")
 }


### PR DESCRIPTION
## Description
Linked Issue GH-19
Adds ability to make REST requests w/ matrix data.  The resulting request looks a little funky, but that's to avoid writing a custom unmarshaller for this :grimacing: 

## Context
One of the next steps in the UI is adding the matrix draw behavior, which requires sending that data over via json.

## Checklist
- [x] - Tests pass
- [ ] - New tests added